### PR TITLE
Replace horizontal ellipsis (U+2026) by '...'

### DIFF
--- a/Source/ComponentModel/Design/TypePicker.Designer.cs
+++ b/Source/ComponentModel/Design/TypePicker.Designer.cs
@@ -74,7 +74,7 @@ namespace BLToolkit.ComponentModel.Design
 			this.addNewLinkLabel.Size = new System.Drawing.Size(100, 13);
 			this.addNewLinkLabel.TabIndex = 1;
 			this.addNewLinkLabel.TabStop = true;
-			this.addNewLinkLabel.Text = "Add Project Type…";
+			this.addNewLinkLabel.Text = "Add Project Type...";
 			this.addNewLinkLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
 			this.addNewLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.addNewLinkLabel_LinkClicked);
 			// 


### PR DESCRIPTION
Since a bit few of system can not display horizontal ellipsis (U+2026) correctly, please pull my simply fix:

https://github.com/songdongsheng/bltoolkit/commit/62c7964e8c93fe94c437161271c8944460a3152f
