### PR TITLE
Added format string for Oracle DATE/TIMESTAMP values.

### DIFF
--- a/Source/Data/Sql/SqlProvider/OracleSqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/OracleSqlProvider.cs
@@ -311,6 +311,10 @@ namespace BLToolkit.Data.Sql.SqlProvider
 					.Append(s.Substring(16, 16))
 					.Append("' as raw(16))");
 			}
+			else if (value is DateTime)
+			{
+				sb.AppendFormat("TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.fffffff}', 'YYYY-MM-DD HH24:MI:SS.FF7')", value);
+			}
 			else
 				base.BuildValue(sb, value);
 		}


### PR DESCRIPTION
BasicSqlProvider converts DateTime values using the following code:

sb.AppendFormat("'{0:yyyy-MM-dd HH:mm:ss.fffffff}'", value);

It doesn't work for Oracle (ORA-01861: literal does not match format string).
So I've overridden OracleSqlProvider.BuildValue() method and added custom format string:

sb.AppendFormat("TO_TIMESTAMP('{0:yyyy-MM-dd HH:mm:ss.fffffff}', 'YYYY-MM-DD HH24:MI:SS.FF7')", value);

It works for both DATE and TIMESTAMP type columns.
Regards, yallie.
