### PR TITLE
Unit test for NPC

### DIFF
--- a/UnitTests/CS/EditableObjects/NotifyPropertyChangedTest.cs
+++ b/UnitTests/CS/EditableObjects/NotifyPropertyChangedTest.cs
@@ -1,0 +1,37 @@
+﻿using System.ComponentModel;
+using BLToolkit.Reflection;
+using BLToolkit.TypeBuilder;
+using NUnit.Framework;
+
+namespace EditableObjects
+{
+	[TestFixture]
+	public class NotifyPropertyChangedTest
+	{
+		[PropertyChanged]
+		public abstract class ObservableObject : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public abstract int ID { get; set; }
+			public abstract string Name { get; set; }
+			public abstract int Seconds { get; set; }
+
+			public static ObservableObject CreateInstance()
+			{
+				return TypeAccessor<ObservableObject>.CreateInstance();
+			}
+		}
+
+		[Test]
+		public void TestPropertyChangedFired()
+		{
+			ObservableObject obj = ObservableObject.CreateInstance();
+			bool propertyChangedFired = false;
+			obj.PropertyChanged += delegate { propertyChangedFired = true; };
+
+			obj.Name = "this should fire PropertyChanged event";
+			Assert.That(propertyChangedFired);
+		}
+	}
+}

--- a/UnitTests/CS/UnitTests.CS.csproj
+++ b/UnitTests/CS/UnitTests.CS.csproj
@@ -177,6 +177,7 @@
     <Compile Include="EditableObjects\InnerObjectTest.cs" />
     <Compile Include="EditableObjects\NestedObjectTest.cs" />
     <Compile Include="EditableObjects\NotifyCollectionChangeTest.cs" />
+    <Compile Include="EditableObjects\NotifyPropertyChangedTest.cs" />
     <Compile Include="JointureTests\Artist.cs" />
     <Compile Include="JointureTests\Artist2.cs" />
     <Compile Include="JointureTests\AssociationTests.cs" />


### PR DESCRIPTION
TypeAccessor can't generate a class that implements INPC and is marked with [PropertyChanged] if it doesn't subclass from EditableObject (which is obviously impossible in Silverlight).
