### PR TITLE
from child in db.GetType<Base>().OfType<Child>() select child - not work/

### DIFF
--- a/UnitTests/Linq/Inheritance.cs
+++ b/UnitTests/Linq/Inheritance.cs
@@ -441,6 +441,20 @@ namespace Data.Linq
 			}
 		}
 
+        [Test]
+        public void QuerySyntaxSimpleTest()
+        {
+            ForEachProvider(Providers.Select(p => p.Name).Except(new[] { ProviderName.Firebird }).ToArray(), context =>
+            {
+                if (context is TestDbManager)
+                {
+                    var db = (TestDbManager)context;
+                    // db.GetTable<Parent111>().OfType<Parent222>().ToList(); - it's work!!!
+                    (from p in db.GetTable<Parent111>().OfType<Parent222>() select p).ToList();
+                }
+            });
+        }
+
 		[TableName("Person")]
 		[InheritanceMapping(Code = 1, Type = typeof(Test17John))]
 		[InheritanceMapping(Code = 2, Type = typeof(Test17Tester))]


### PR DESCRIPTION
See test

```
                // db.GetTable<Parent111>().OfType<Parent222>().ToList(); - it's work!!!
                (from p in db.GetTable<Parent111>().OfType<Parent222>() select p).ToList(); // not work
```

raise System.ArgumentException : Expression of type 'Data.Linq.Inheritance+Parent111' cannot be used for return type 'Data.Linq.Inheritance+Parent222'
