### PR TITLE
Linq Insert with subqueries that contains Where

### DIFF
--- a/Source/Data/Linq/Builder/ExpressionContext.cs
+++ b/Source/Data/Linq/Builder/ExpressionContext.cs
@@ -70,7 +70,7 @@ namespace BLToolkit.Data.Linq.Builder
 		{
 			switch (requestFlag)
 			{
-				case RequestFor.Root        : return expression == Lambda.Parameters[0];
+				case RequestFor.Root        :  return Lambda.Parameters.Count > 0 && expression == Lambda.Parameters[0];
 
 				case RequestFor.Table       :
 				case RequestFor.Association :


### PR DESCRIPTION
```
    public void Insert14()
    {
        ForEachProvider(db =>
        {
            try
            {
                db.Person.Delete(p => p.FirstName.StartsWith("Insert14"));

                Assert.AreEqual(1,
                    db.Person
                    .Insert(() => new Person
                    {
                        FirstName = "Insert14" + db.Person.Where(p => p.ID == 1).Select(p => p.FirstName).FirstOrDefault(),
                        LastName = "Shepard",
                        Gender = Gender.Male
                    }));

                Assert.AreEqual(1, db.Person.Count(p => p.FirstName.StartsWith("Insert14")));
            }
            finally
            {
                db.Person.Delete(p => p.FirstName.StartsWith("Insert14"));
            }
        });
    }
```
