### PR TITLE
The VB template translates the one to one foreign keys wrong

### DIFF
--- a/Source/Templates/VB.ttinclude
+++ b/Source/Templates/VB.ttinclude
@@ -59,7 +59,11 @@ RenderForeignKey = (tt,key) =>
 {
 	WriteComment(tt, " " + key.KeyName);
 
-	var type = string.Format(OneToManyAssociationType, key.OtherTable.ClassName);
+	var type = "" ;
+	if (key.AssociationType == AssociationType.OneToMany)
+		type = string.Format(OneToManyAssociationType, key.OtherTable.ClassName);
+	else
+		type = key.OtherTable.ClassName ;
 
 	if (!RenderField)
 		WriteLine("Private _{0} As {1}", key.MemberName, type);


### PR DESCRIPTION
CORRECTION: the VB template translates the one to one foreign keys as if it were one to many.
for example in the table Products, the FK to Categories was generated

```
    Private _Category As IEnumerable(Of Category)
```

instead of the correct 

```
    Private _Category As Category
```

To reproduce the error
1. edit the file linq/demo/datamodel/Northwind.tt and add the 5 line
   <#@ include file="vb.ttinclude"     #>
2. copy VB.ttinclude file from templates
3. regenerate Northwind.generated.vb
