### PR TITLE
InvalidOperationException during execution of query building

### DIFF
--- a/UnitTests/Linq/IdlTest.cs
+++ b/UnitTests/Linq/IdlTest.cs
@@ -390,6 +390,30 @@ namespace Data.Linq
                     Assert.That(queryList.ToList(), Is.EqualTo(queryArray.ToList()));
                 });
         }
+
+        [Test]
+        public void ConcatJoinOrderByTest()
+        {
+            ForMySqlProvider(
+                db =>
+                {
+
+                    var query = from y in
+                                    ((from pat in db.Patient
+                                      where pat.Diagnosis == "a"
+                                      select pat)
+                                    .Concat
+                                    (from pat in db.Patient
+                                     where pat.Diagnosis == "b"
+                                     select pat))
+                                join person in db.Person on y.PersonID equals person.ID
+                                orderby person.ID
+                                select new { Id = person.ID, Id2 = y.PersonID };
+
+                    Assert.That(query.ToList(), Is.Not.Null);
+
+                });
+        }
     }
 
     #region TestConvertFunction classes


### PR DESCRIPTION
Please look at ConcatJoinOrderByTest in IdlTest.cs.
It generate System.InvalidOperationException : Operation is not valid due to the current state of the object.
