### PR TITLE
IdlTest.TestMonoConcat() test added

### DIFF
--- a/UnitTests/Linq/IdlTest.cs
+++ b/UnitTests/Linq/IdlTest.cs
@@ -414,6 +414,27 @@ namespace Data.Linq
 
                 });
         }
+
+        [Test]
+        public void TestMonoConcat()
+        {
+            ForMySqlProvider(
+                db =>
+                    {
+                        var ds = new IdlPatientSource(db);
+                        var t = "A";
+                        var query =
+                            (from y in ds.Persons()
+                             select y.Name)
+                                .Concat(
+                                    from x in ds.Persons()
+                                    where x.Name == t
+                                    select x.Name
+                                );
+
+                        Assert.That(query.ToList(), Is.Not.Null);
+                    });
+        }
     }
 
     #region TestConvertFunction classes


### PR DESCRIPTION
Test fails with mono 2.10.5 windows and unix.

Test can be executed in Mono command prompt with command
mono --debug --runtime=v4.0.30319 ........\tools\nunit\nunit-console.exe --run Data.Linq.IdlTest.TestMonoConcat UnitTests.Linq.dll
