### PR TITLE
IdlTest.TestMono03() test added

### DIFF
--- a/UnitTests/Linq/IdlTest.cs
+++ b/UnitTests/Linq/IdlTest.cs
@@ -480,6 +480,27 @@ namespace Data.Linq
         public void TestMono01()
         {
             ForMySqlProvider(
+                 db =>
+                 {
+                     var ds = new IdlPatientSource(db);
+                     var t = "A";
+                     var query =
+                         (from y in ds.Persons()
+                          select y.Name)
+                             .Concat(
+                                 from x in ds.Persons()
+                                 where x.Name == t
+                                 select x.Name
+                             );
+
+                     Assert.That(query.ToList(), Is.Not.Null);
+                 });
+        }
+
+        [Test]
+        public void TestMono03()
+        {
+            ForMySqlProvider(
                 db => Assert.That(new GenericConcatQuery(db, new object[] { "A", 1 }).Query().ToList(), Is.Not.Null));
         }
 


### PR DESCRIPTION
Test fails with mono 2.10.8 windows.

Test can be executed in Mono command prompt with command
mono --debug --runtime=v4.0.30319 ........\Tools\NUnit\nunit-console.exe --run=Data.Linq.IdlTest.TestMono03 UnitTests.Linq.dll

PS The TestMono01 is the test  formerly TestMonoConcat().
