### PR TITLE
Using sequences in PostgreSQL

### DIFF
--- a/Source/Data/Sql/SqlProvider/PostgreSQLSqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/PostgreSQLSqlProvider.cs
@@ -187,6 +187,18 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 			return value;
 		}
+		
+		 public override ISqlExpression GetIdentityExpression(SqlTable table, SqlField identityField, bool forReturning)
+	        {
+	            if (table.SequenceAttributes != null)
+	            {
+	                var attr = GetSequenceNameAttribute(table, false);
+	
+	                if (attr != null)
+	                    return new SqlExpression("nextval('" + attr.SequenceName+"')", Precedence.Primary);
+	            }
+	            return base.GetIdentityExpression(table, identityField, forReturning);
+	        }
 
 		//protected override void BuildInsertOrUpdateQuery(StringBuilder sb)
 		//{


### PR DESCRIPTION
This code allows to use sequences as insertions.

To enable inserts in posgresql mapping can be done like

```
[TableName(Owner="public", Name="testTable")]
public partial class testTable
{
    [PrimaryKey(1), SequenceName("table_seq"), Identity] 
    public Int32    id            { get; set; } 
    public String   name       { get; set; } // character varying(40)(40)
}
```
