### PR TITLE
TestIsContainedInArrayOfEnumValues test added

### DIFF
--- a/UnitTests/Linq/IdlTest.cs
+++ b/UnitTests/Linq/IdlTest.cs
@@ -416,6 +416,21 @@ namespace Data.Linq
                 });
         }
 
+        [Test]
+        public void TestIsContainedInArrayOfEnumValues()
+        {
+            var types2 = new[] { TypeValue.Value2, TypeValue.Value3, TypeValue.Value4 };
+
+            ForMySqlProvider(
+                db =>
+                    {
+                        var result = (from x in db.Parent4 where types2.Contains(x.Value1) select x)
+                            .ToList();
+
+                        Assert.That(result, Is.Not.Null);
+                    });
+        }
+
         #region GenericQuery classes
 
         public abstract partial class GenericQueryBase


### PR DESCRIPTION
This test generates following SQL

<pre>
SELECT
    x.ParentID,
    x.Value1
FROM
    Parent x
WHERE
    x.Value1 IN (Value2, Value3, Value4)
</pre>


where "Value2, Value3, Value4" is names of array of enums, not values.
