### PR TITLE
BLToolkit skips "orderby" field (Test ConcatOrderByTest added)

### DIFF
--- a/UnitTests/Linq/IdlTest.cs
+++ b/UnitTests/Linq/IdlTest.cs
@@ -511,6 +511,29 @@ namespace Data.Linq
                     });
         }
 
+        [Test]
+        public void ConcatOrderByTest()
+        {
+            ForMySqlProvider(
+                db =>
+                {
+                    var q = from p in db.Person
+                             where p.ID < 0
+                             select new { Rank = 0, FirstName = (string)null, LastName = (string)null };
+                    var q2 =
+                        q.Concat(
+                            from p in db.Person
+                            select new { Rank = p.ID, p.FirstName, p.LastName });
+
+                    var resultquery = (from x in q2 orderby x.Rank, x.FirstName, x.LastName select x).ToString();
+                    
+                    var rqr = resultquery.LastIndexOf("ORDER BY", System.StringComparison.InvariantCultureIgnoreCase);
+                    var rqp = (resultquery.Substring(rqr + "ORDER BY".Length).Split(',')).Select(p => p.Trim()).ToArray();
+                 
+                    Assert.That(rqp.Count(),  Is.EqualTo(3));
+                });
+        }
+
         #region GenericQuery classes
 
         public abstract partial class GenericQueryBase


### PR DESCRIPTION
following query

``` c#
var q = from p in db.Person
   where p.ID < 0
   select new { Rank = 0, FirstName = (string)null, LastName = (string)null };
var q2 =
   q.Concat(
        from p in db.Person
        select new { Rank = p.ID, p.FirstName, p.LastName });
var resultquery = from x in q2 orderby x.Rank, x.FirstName, x.LastName select x);
```

generate SQL with missed ORDER BY parameters more than 2 parameter

``` sql
SELECT
    t1.c1 as c11,
    t1.c2 as c21,
    t1.c3 as c31
FROM
    (
        SELECT
            0 as c1,
            NULL as c2,
            NULL as c3
        FROM
            Person p
        WHERE
            p.PersonID < 0
        UNION ALL
        SELECT
            p1.PersonID as c1,
            p1.FirstName as c2,
            p1.LastName as c3
        FROM
            Person p1
    ) t1
ORDER BY
    t1.c1,
    t1.c2
```
