### PR TITLE
Allowed UDT Parameters to be passed as arguments in generated code

### DIFF
--- a/Source/DataAccess/UserDefinedTypeAttribute.cs
+++ b/Source/DataAccess/UserDefinedTypeAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BLToolkit.DataAccess
+{
+    /// <summary>
+    /// This attribute is used to represent that a type is a UDT type linked to a UDT Type in the DB (Used most commanly in Oracle)
+    /// 
+    /// Without this attribute if you try to use the code generation method to call a Stored Procedure in the DB and try to pass the UDT as a parm 
+    /// BLToolkit will flaten the object and cause error's
+    /// 
+    /// Another solution is to convert your UDT to a Struct which also causes BLToolkits 'IsScaler()' Method to return true.
+    /// </summary>
+    class UserDefinedTypeAttribute : Attribute
+    {
+    }
+}

--- a/Source/Reflection/TypeHelper.cs
+++ b/Source/Reflection/TypeHelper.cs
@@ -9,6 +9,8 @@ using System.Reflection;
 using System.Xml;
 #if !SILVERLIGHT
 using System.Xml.Linq;
+using BLToolkit.DataAccess;
+
 #endif
 
 namespace BLToolkit.Reflection
@@ -1337,6 +1339,7 @@ namespace BLToolkit.Reflection
 				|| type == typeof(System.Data.Linq.Binary)
 				|| type == typeof(Stream)
 				|| type == typeof(XmlReader)
+                || type.GetCustomAttributes(typeof(UserDefinedTypeAttribute),true).Any() // If the type is a UDT pass it as is
 #if !SILVERLIGHT
 				|| type == typeof(XmlDocument)
 				|| type == typeof(XElement)


### PR DESCRIPTION
Fixed bug with UDT parameters in Generated code being flattened causing runtime exceptions and preventing the use of UDT's with Auto generated code
