### PR TITLE
Забавное поведение.

### DIFF
--- a/Source/DataAccess/DataAccessorBuilder.cs
+++ b/Source/DataAccess/DataAccessorBuilder.cs
@@ -425,6 +425,8 @@ namespace BLToolkit.DataAccess
 			if (attrs.Length != 0)
 				_objectType = ((ObjectTypeAttribute)attrs[0]).ObjectType;
 
+
+			// why not _objectType =  mi.ReturnType ? 
 			if (_objectType == null)
 			{
 				Type[] types = TypeHelper.GetGenericArguments(mi.DeclaringType, typeof(DataAccessor));


### PR DESCRIPTION
 [SqlQuery(@"select u.[Login] as [Login], g.Name as [Group]
                    from AuthUsers as u 
                    join AuthUserGroups as g on u.ID_AuthUserGroups = g.ID
                    where u.ID = @uid")]
        public abstract UserInfo GetUserInfo(int @uid);

если явно не наследоваться от DataAccessor < UserInfo > или не пометить метод  [ObjectType(typeof(UserInfo))], то при исполнении метод возвращает объект типа DataAccessor. Это приводит к неопределенному поведению. Либо я делаю что-то не так, либо это действительно баг. 

Почему просто не брать за тип для ExecuteObject тип, который возвращает метод или по крайней мере кидать исключение при конструировании метода?
