### PR TITLE
SqlCommand.Prepare method requires all variable length parameters to have an explicitly set non-zero Size.

### DIFF
--- a/Source/Data/DataProvider/SqlDataProviderBase.cs
+++ b/Source/Data/DataProvider/SqlDataProviderBase.cs
@@ -404,6 +404,11 @@ namespace BLToolkit.Data.DataProvider
 			{
 				parameter.Value = (long)(ulong)value;
 			}
+			else if (value is string)
+			{
+				parameter.Value = value;
+				if (parameter.DbType == DbType.String && ((string)value).Length == 0) parameter.Size = 1;
+			}
 			else
 			{
 				base.SetParameterValue(parameter, value);


### PR DESCRIPTION
This addresses the error when empty string is passed to a varchar command parameter: 

_SqlCommand.Prepare method requires all variable length parameters to have an explicitly set non-zero Size._
