### PR TITLE
nullable char field is not handled correctly by ExpressionBuilder

### DIFF
--- a/Source/Data/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
+++ b/Source/Data/Linq/Builder/ExpressionBuilder.SqlBuilder.cs
@@ -1278,6 +1278,22 @@ namespace BLToolkit.Data.Linq.Builder
 				}
 			}
 
+            #region special case for char?
+
+            if (left.NodeType == ExpressionType.Convert && left.Type == typeof(int?) && right.NodeType == ExpressionType.Convert)
+            {
+                var convLeft = left as UnaryExpression;
+                var convRight = right as UnaryExpression;
+
+                if (convLeft != null && convRight != null && convLeft.Operand.Type == typeof(char?))
+                {
+                    left = convLeft.Operand;
+                    right = Expression.Constant(ConvertTo<char?>.From(((ConstantExpression)convRight.Operand).Value));
+                }
+            }
+
+            #endregion
+
 			switch (nodeType)
 			{
 				case ExpressionType.Equal    :


### PR DESCRIPTION
I have an Oracle database and I was executing LINQ select from a table. Filter expression was on a nullable char field. 

I had an expression like

var q = Db.Table.Where(x => x.Field == 'Y')

and it was translated into something like

SELECT
*
FROM Table 
WHERE Field=89

note that 'Y' was translated into 89 and obviously Oracle did not accept it.
