### PR TITLE
When DBType is Binary, use it on Null Values

### DIFF
--- a/Source/Data/DbManager.cs
+++ b/Source/Data/DbManager.cs
@@ -2612,9 +2612,7 @@ namespace BLToolkit.Data
 
 						IDbDataParameter p;
 
-						//if ((value == null || value == DBNull.Value) && dbType == DbType.Byte || type == typeof(byte[]) || type == typeof(System.Data.Linq.Binary))
-						// I do not get this change.                      ^^^^^^^^^^^^^^^^^^^^^
-						if ((value == null || value == DBNull.Value) && type == typeof(byte[]) || type == typeof(System.Data.Linq.Binary))
+						if ((value == null || value == DBNull.Value) && dbType == DbType.Binary || type == typeof(byte[]) || type == typeof(System.Data.Linq.Binary))
 						{
 							p = Parameter(baseParameters[i].ParameterName + nRows, DBNull.Value, DbType.Binary);
 						}


### PR DESCRIPTION
Sorry, with my last commit, I typed DBType.Byte, this was wrong.

With DBType Binary it should work!

Fixes #170
