### PR TITLE
Nullable<>.HasValue and unnecessary select from select

### DIFF
--- a/UnitTests/Linq/SelectTest.cs
+++ b/UnitTests/Linq/SelectTest.cs
@@ -272,6 +272,23 @@ namespace Data.Linq
 		}
 
 		[Test]
+		public void MutiplySelect12([DataContexts(ExcludeLinqService = true)] string context)
+		{
+			using (var db = (TestDbManager)GetDataContext(context))
+			{
+				var q =
+					from grandChild in db.GrandChild
+					from child in db.Child
+					where grandChild.ChildID.HasValue
+					select grandChild;
+				q.ToList();
+
+				var selectCount = db.LastQuery.Split(' ', '\t', '\n', '\r').Count(s => s.Equals("select", StringComparison.InvariantCultureIgnoreCase));
+				Assert.AreEqual(1, selectCount, "Why do we need \"select from select\"??");
+			}
+		}
+
+		[Test]
 		public void Coalesce()
 		{
 			ForEachProvider(db =>


### PR DESCRIPTION
from grandChild in db.GrandChild
from child in db.Child
where grandChild.ChildID.HasValue
select grandChild;

generate 

SELECT
    t3.ParentID as ParentID1,
    t3.ChildID as ChildID1,
    t3.GrandChildID as GrandChildID1
FROM
    (
        SELECT   -- what is it ????
            t1.ChildID,
            t1.ParentID,
            t1.GrandChildID
        FROM
            GrandChild t1,
            Child t2
    ) t3
WHERE
    t3.ChildID IS NOT NULL

I think, bltoolkit should generate 
SELECT
  t1.ChildID,
  t1.ParentID,
  t1.GrandChildID
FROM
  GrandChild t1,
  Child t2
t1.ChildID IS NOT NULL
