### PR TITLE
Ошибка при маппинге свойства интерфейсного типа

### DIFF
--- a/Source/Data/Linq/Query.cs
+++ b/Source/Data/Linq/Query.cs
@@ -503,7 +503,7 @@ namespace BLToolkit.Data.Linq
 				getter = i == 0 ? pof : Expression.Condition(Expression.Equal(getter, Expression.Constant(null)), defValue, pof);
 			}
 
-			if (!mm.Type.IsClass && mm.MapMemberInfo.Nullable && !TypeHelper.IsNullableType(mm.Type))
+			if (!mm.Type.IsClass && !mm.Type.IsInterface && mm.MapMemberInfo.Nullable && !TypeHelper.IsNullableType(mm.Type))
 			{
 				var method = ReflectionHelper.Expressor<int>.MethodExpressor(_ => ConvertNullable(0, 0))
 					.GetGenericMethodDefinition()


### PR DESCRIPTION
Есть класс со свойством:

``` c#
public class Bar
{
    //...
    [Column(CanBeNull = true, DbType = "uniqueidentifier")]
    [MemberMapper(typeof(IFooMapper))]
    public IFoo Foo
    {
        get { return foo; }
        set { foo = value; }
    }
    //...
}
```

IFoo — это сущность (entity), которая хранится в другом месте, независимо от Bar. IFooMapper отвечает за преобразование экземпляра IFoo в id и обратно.

При попытке сохранить экземпляр Bar в БД в процессе маппинга BLToolkit падает.

Предложенный код решает проблему.
