### PR TITLE
MsSQL 2012 support

### DIFF
--- a/Source/BLToolkit.4.csproj
+++ b/Source/BLToolkit.4.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Data\DataProvider\Sql2000DataProvider.cs" />
     <Compile Include="Data\DataProvider\FirebirdMappingSchema.cs" />
     <Compile Include="Data\DataProvider\Sql2008DataProvider.cs" />
+    <Compile Include="Data\DataProvider\Sql2012DataProvider.cs" />
     <Compile Include="Data\DataProvider\SqlDataProvider.cs" />
     <Compile Include="Data\DataProvider\ProviderName.cs" />
     <Compile Include="Data\IDataReaderEx.cs" />
@@ -252,6 +253,7 @@
     <Compile Include="Data\Linq\QueryableAccessor.cs" />
     <Compile Include="Data\Linq\TableT.cs" />
     <Compile Include="Data\Sql\SqlProvider\MsSql2000SqlProvider.cs" />
+    <Compile Include="Data\Sql\SqlProvider\MsSql2012SqlProvider.cs" />
     <Compile Include="Data\Sql\SqlValueBase.cs" />
     <Compile Include="Linq\ExpressionHelper.cs" />
     <Compile Include="Data\Linq\ExpressionQueryImpl.cs" />

--- a/Source/BLToolkit.CP.4.csproj
+++ b/Source/BLToolkit.CP.4.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Data\DataProvider\OracleHelper.cs" />
     <Compile Include="Data\DataProvider\Sql2000DataProvider.cs" />
     <Compile Include="Data\DataProvider\Sql2008DataProvider.cs" />
+    <Compile Include="Data\DataProvider\Sql2012DataProvider.cs" />
     <Compile Include="Data\DataProvider\SqlDataProvider.cs" />
     <Compile Include="Data\DataProvider\ProviderName.cs" />
     <Compile Include="Data\IDataReaderEx.cs" />
@@ -248,6 +249,7 @@
     <Compile Include="Data\Linq\MemberInfoComparer.cs" />
     <Compile Include="Data\Linq\QueryableAccessor.cs" />
     <Compile Include="Data\Sql\SqlProvider\MsSql2000SqlProvider.cs" />
+    <Compile Include="Data\Sql\SqlProvider\MsSql2012SqlProvider.cs" />
     <Compile Include="Data\Sql\SqlValueBase.cs" />
     <Compile Include="Linq\ExpressionHelper.cs" />
     <Compile Include="Data\Linq\ExpressionQuery.cs" />

--- a/Source/BLToolkit.Data.4.csproj
+++ b/Source/BLToolkit.Data.4.csproj
@@ -263,6 +263,7 @@
     <Compile Include="DataAccess\SequenceKeyGenerator.cs" />
     <Compile Include="DataAccess\SqlIgnoreAttribute.cs" />
     <Compile Include="Data\DataExceptionType.cs" />
+    <Compile Include="Data\DataProvider\Sql2012DataProvider.cs" />
     <Compile Include="Data\DataProvider\DataProviderInterpreterBase.cs" />
     <Compile Include="Data\DataProvider\FirebirdMappingSchema.cs" />
     <Compile Include="Data\DataProvider\Interpreters\OracleDataProviderInterpreter.cs" />
@@ -308,6 +309,7 @@
     <Compile Include="Data\Linq\ITable.cs" />
     <Compile Include="Data\Linq\MemberInfoComparer.cs" />
     <Compile Include="Data\Linq\QueryableAccessor.cs" />
+    <Compile Include="Data\Sql\SqlProvider\MsSql2012SqlProvider.cs" />
     <Compile Include="Data\Sql\SqlProvider\MsSql2000SqlProvider.cs" />
     <Compile Include="Data\Sql\SqlValueBase.cs" />
     <Compile Include="Linq\ExpressionHelper.cs" />

--- a/Source/BLToolkit.SL.4.csproj
+++ b/Source/BLToolkit.SL.4.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Data\Sql\SqlProvider\ISqlProvider.cs" />
     <Compile Include="Data\Sql\SqlProvider\MsSql2005SqlProvider.cs" />
     <Compile Include="Data\Sql\SqlProvider\MsSql2008SqlProvider.cs" />
+    <Compile Include="Data\Sql\SqlProvider\MsSql2012SqlProvider.cs" />
     <Compile Include="Data\Sql\SqlProvider\MSSqlSqlProvider.cs" />
     <Compile Include="Data\Sql\SqlProvider\MySqlSqlProvider.cs" />
     <Compile Include="Data\Sql\SqlProvider\OracleSqlProvider.cs" />

--- a/Source/Data/DataProvider/ProviderName.cs
+++ b/Source/Data/DataProvider/ProviderName.cs
@@ -9,6 +9,7 @@
 		public const string MsSql         = "Sql";
         public const string MsSql2000     = "MsSql2000";
 		public const string MsSql2008     = "MsSql2008";
+        public const string MsSql2012     = "MsSql2012";
 		public const string MySql         = "MySql";
 		public const string Odbc          = "Odbc";
 		public const string OleDb         = "OleDb";

--- a/Source/Data/DataProvider/Sql2012DataProvider.cs
+++ b/Source/Data/DataProvider/Sql2012DataProvider.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace BLToolkit.Data.DataProvider
+{
+	using Sql.SqlProvider;
+
+	public sealed class Sql2012DataProvider : SqlDataProviderBase
+	{
+		static readonly List<Func<Type,string>> _udtTypeNameResolvers = new List<Func<Type, string>>();
+
+        static Sql2012DataProvider()
+		{
+			AddUdtTypeNameResolver(ResolveStandartUdt);
+		}
+
+		public static void AddUdtTypeNameResolver(Func<Type, string> resolver)
+		{
+			_udtTypeNameResolvers.Add(resolver);
+		}
+
+		static string ResolveStandartUdt(Type type)
+		{
+			return type.Namespace == "Microsoft.SqlServer.Types" ? type.Name.Replace("Sql", "") : null;
+		}
+
+		public override string Name
+		{
+			get { return DataProvider.ProviderName.MsSql2012; }
+		}
+
+		public override ISqlProvider CreateSqlProvider()
+		{
+			return new MsSql2012SqlProvider();
+		}
+
+		public override void SetParameterValue(IDbDataParameter parameter, object value)
+		{
+			base.SetParameterValue(parameter, value);
+			SetUdtTypeName(parameter, value);
+		}
+
+		static void SetUdtTypeName(IDbDataParameter parameter, object value)
+		{
+			var sqlParameter = parameter as System.Data.SqlClient.SqlParameter;
+			var valueType    = value.GetType();
+
+			if (sqlParameter != null)
+				sqlParameter.UdtTypeName = _udtTypeNameResolvers.Select(_=>_(valueType)).FirstOrDefault(_=>!string.IsNullOrEmpty(_));
+		}
+	}
+}

--- a/Source/Data/Sql/SqlProvider/MsSql2012SqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/MsSql2012SqlProvider.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Text;
+
+namespace BLToolkit.Data.Sql.SqlProvider
+{
+	public class MsSql2012SqlProvider : MsSqlSqlProvider
+	{
+		protected override ISqlProvider CreateSqlProvider()
+		{
+			return new MsSql2012SqlProvider();
+		}
+
+		protected override void BuildInsertOrUpdateQuery(StringBuilder sb)
+		{
+			BuildInsertOrUpdateQueryAsMerge(sb, null);
+			sb.AppendLine(";");
+		}
+	}
+}

--- a/Source/Reflection/MemberAccessor.cs
+++ b/Source/Reflection/MemberAccessor.cs
@@ -3,11 +3,10 @@ using System.Data.SqlTypes;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.ComponentModel;
+using BLToolkit.Data.Linq;
 
 #if !SILVERLIGHT && !DATA
 using BLToolkit.ComponentModel;
-using BLToolkit.Data.Linq;
-
 #endif
 
 namespace BLToolkit.Reflection


### PR DESCRIPTION
I started with MsSQL 2012 support (included the classes), but I could not find where you generate this rownumber SQL, so maybe you can implement to use Tak and Offset instead of Rownumber syntax.

I also included automatic SQL Server Version detection, if no connection could be established, it falls back to the old method.

And I use SQL2008 for MSSQL 2005 because it also supports Rownumbers to support Take and Skip
