### PR TITLE
Fix issue with FluentMap.NullValue

### DIFF
--- a/Source/Mapping/Fluent/FluentMap.Interface.cs
+++ b/Source/Mapping/Fluent/FluentMap.Interface.cs
@@ -258,7 +258,7 @@ namespace BLToolkit.Mapping.Fluent
 		void IFluentMap.NullValue<TR>(string propName, TR value)
 		{
 			var member = this.GetMemberExtension(propName);
-			member.Attributes.Add(Attributes.NullValue, Convert.ToString(value));
+			member.Attributes.Add(Attributes.NullValue, Equals(value, null) ? null : Convert.ToString(value));
 			this.EachChilds(m => m.NullValue(propName, value));
 		}
 

--- a/Source/Reflection/MetadataProvider/ExtensionMetadataProvider.cs
+++ b/Source/Reflection/MetadataProvider/ExtensionMetadataProvider.cs
@@ -21,11 +21,9 @@ namespace BLToolkit.Reflection.MetadataProvider
 
 		private static object GetValue(TypeExtension typeExtension, MemberAccessor member, string elemName, out bool isSet)
 		{
-			var value = typeExtension[member.Name][elemName].Value;
-
-			isSet = value != null;
-
-			return value;
+			AttributeExtensionCollection ext;
+			isSet = typeExtension[member.Name].Attributes.TryGetValue(elemName, out ext);
+			return isSet ? ext.Value : null;
 		}
 
 		#endregion

--- a/UnitTests/CS/Mapping/TestFluentNullable.cs
+++ b/UnitTests/CS/Mapping/TestFluentNullable.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using BLToolkit.Mapping;
+using BLToolkit.Mapping.Fluent;
+using NUnit.Framework;
+
+namespace UnitTests.CS.Mapping
+{
+	[TestFixture]
+	public class TestFluentNullable
+	{
+		public class TestObject
+		{
+			public string NullableString { get; set; }
+		}
+
+		public class TestObjectMap : FluentMap<TestObject>
+		{
+			public TestObjectMap ()
+			{
+				NullValue (x => x.NullableString, null).Nullable ();
+			} 
+		}
+
+		[Test]
+		public void TestFluentNullValue ()
+		{
+			var schema = new MappingSchema ();
+			FluentConfig.Configure (schema).MapingFromType<TestObjectMap> ();
+			var om = schema.GetObjectMapper (typeof (TestObject));
+			var instance = new TestObject () { NullableString = "SOMEVALUE" };
+			om.SetValue (instance, "NullableString", null);
+			Assert.AreEqual (null, instance.NullableString);
+		}
+
+
+		
+
+	}
+}

--- a/UnitTests/CS/UnitTests.CS.csproj
+++ b/UnitTests/CS/UnitTests.CS.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Mapping\ObjectMapperAttributeTest.cs" />
     <Compile Include="Mapping\ObjectMapperTest.cs" />
     <Compile Include="Mapping\ResultSetTest.cs" />
+    <Compile Include="Mapping\TestFluentNullable.cs" />
     <Compile Include="Mapping\TrimmableAttributeTest.cs" />
     <Compile Include="Mapping\XmlMap.cs" />
     <Compile Include="Patterns\MustImplementAttributeTest.cs" />


### PR DESCRIPTION
Hello. NullValue(null) doesn't work when applied via FluentMap (it works like a charm with attributes)

Actually there are two bugs:
1) Incorrect value passed to member.Attributes.Add
2) Incorrect isSet detection in ExtensionMetadataProvider

Here is a fix for them + a unit test (I wasn't sure where to place it, since the bug is related to 2 subsystems)
