### PR TITLE
Fix 'InsertBatch'

### DIFF
--- a/Source/Data/DataProvider/SqlDataProviderBase.cs
+++ b/Source/Data/DataProvider/SqlDataProviderBase.cs
@@ -260,8 +260,12 @@ namespace BLToolkit.Data.DataProvider
 				DestinationTableName = tbl,
 			};
 
-			foreach (var memberMapper in members)
-				bc.ColumnMappings.Add(new SqlBulkCopyColumnMapping(memberMapper.Ordinal, memberMapper.Name));
+			int	index	=	0;
+			foreach	(var memberMapper	in members)
+			{
+				bc.ColumnMappings.Add(new	SqlBulkCopyColumnMapping(index,	memberMapper.Name));
+				index	+= 1;
+			}
 
 			bc.WriteToServer(rd);
 


### PR DESCRIPTION
Problem: 'BulkCopyReader.GetValue' relies on _members index, not on 'memberMapper.Ordinal', and here, in example, field 'id' is not inside _members, so, we get out of index exception.

To reproduce problem:

``` sql
create table test
(
  id int not null identity(1, 1),
  data nvarchar(50),
  constraint pk_test primary key(id)
)
```

``` cs
  public class Test
  {
    [PrimaryKey, NonUpdatable, Identity]
    public int    id;
    public string data;
 }

using (var db = new DbManager())
{
    var testlist = new List<Test>();

    db.BeginTransaction();

    testlist.Add(new Test { data = "1" });
    testlist.Add(new Test { data = "2" });

    db.InsertBatch(testlist);

    db.CommitTransaction();
}
```
