### PR TITLE
Fix SqlServer's InsertBatch with transaction

### DIFF
--- a/Source/Data/DataProvider/SqlDataProviderBase.cs
+++ b/Source/Data/DataProvider/SqlDataProviderBase.cs
@@ -248,13 +248,10 @@ namespace BLToolkit.Data.DataProvider
 			int                            maxBatchSize,
 			DbManager.ParameterProvider<T> getParameters)
 		{
-			if (db.Transaction != null)
-				return base.InsertBatch(db, insertText, collection, members, maxBatchSize, getParameters);
-
 			var idx = insertText.IndexOf('\n');
 			var tbl = insertText.Substring(0, idx).Substring("INSERT INTO ".Length).TrimEnd('\r');
 			var rd  = new BulkCopyReader(members, collection);
-			var bc  = new SqlBulkCopy((SqlConnection)db.Connection, SqlDataProvider.SqlBulkCopyOptions, null)
+			var bc  = new SqlBulkCopy((SqlConnection)db.Connection, SqlDataProvider.SqlBulkCopyOptions, (SqlTransaction)db.Transaction)
 			{
 				BatchSize            = maxBatchSize,
 				DestinationTableName = tbl,


### PR DESCRIPTION
This is again fix for issue 271 - by some reason BLToolkit doesn't SqlBulkCopy when DbManager has open transaction.
