### PR TITLE
Better handling for VB.Net Linq expression

### DIFF
--- a/UnitTests/Linq/VisualBasicCommon.vb
+++ b/UnitTests/Linq/VisualBasicCommon.vb
@@ -22,4 +22,13 @@ Public Module VisualBasicCommon
             Select cust.CustomerID
     End Function
 
+    Public Function SearchCondition3(ByVal db As NorthwindDB) As IEnumerable(Of Integer)
+        '#11/14/1997#
+        Dim query = From order In db.Order
+            Where order.OrderDate = New DateTime(1997, 11, 14)
+            Select order.OrderID
+
+        Return query
+    End Function
+
 End Module

--- a/UnitTests/Linq/VisualBasicTest.cs
+++ b/UnitTests/Linq/VisualBasicTest.cs
@@ -62,5 +62,26 @@ namespace Data.Linq
 					VisualBasicCommon.SearchCondition2(db));
 			}
 		}
+
+        [Test]
+        public void SearchCondition3([IncludeDataContexts("Northwind")] string context)
+        {
+            using (var db = new NorthwindDB())
+            {
+
+                var cQuery = from order in db.Order
+                             where order.OrderDate == new DateTime(1997, 11, 14)
+                    select order.OrderID;
+
+                var cSharpResults = cQuery.ToList();
+
+                var vbResults = (VisualBasicCommon.SearchCondition3(db)).ToList();
+
+                AreEqual(
+                    cSharpResults,
+                    vbResults);
+            }
+        }
+
 	}
 }


### PR DESCRIPTION
This fixes #318. VB.Net generates a different Linq query than C# when dealing with nullable properties. Added handling for that.
