### PR TITLE
null decimal error

### DIFF
--- a/Source/Data/DbManager.cs
+++ b/Source/Data/DbManager.cs
@@ -2389,6 +2389,8 @@ namespace BLToolkit.Data
 					}
 					else if (p.Value is DBNull)
 					{
+						if (p.DbType == DbType.Decimal)
+                            				p.Precision = 1;
 						p.Size = 1;
 					}
 					else if (p.Value is byte[])


### PR DESCRIPTION
Fixed error with the batch update when any nullable decimal member in the list was set to null. The BLToolkit was unable to determine the precision for the decimal type.