### PR TITLE
null decimal error

### DIFF
--- a/Data/Create Scripts/MsSql.sql
+++ b/Data/Create Scripts/MsSql.sql
@@ -553,3 +553,11 @@ CREATE TABLE TestIdentity (
 	ID int NOT NULL IDENTITY(1,1) CONSTRAINT PK_TestIdentity PRIMARY KEY CLUSTERED
 )
 GO
+
+CREATE TABLE TestProduct
+(
+	ID             int NOT NULL,
+	Name           nvarchar(50) NOT NULL,
+	Price		   decimal(18,2) NULL
+)
+GO

--- a/Source/Data/DbManager.cs
+++ b/Source/Data/DbManager.cs
@@ -2389,6 +2389,8 @@ namespace BLToolkit.Data
 					}
 					else if (p.Value is DBNull)
 					{
+                        if (p.DbType == DbType.Decimal)
+                            p.Precision = 1;
 						p.Size = 1;
 					}
 					else if (p.Value is byte[])

--- a/UnitTests/Linq/BatchTest.cs
+++ b/UnitTests/Linq/BatchTest.cs
@@ -83,5 +83,33 @@ namespace Update
 				((DbManager)db).InsertBatch(new[] { new Area { AreaCode = 1 } });
 			}
 		}
+
+        [TableName( "TestProduct" )]
+        public class TestProduct
+        {
+            [MapField( "ID" )]
+            public int ID { get; set; }
+
+            [MapField( "Name" )]
+            public string Name { get; set; }
+
+            [MapField( "Price" )]
+            public decimal? Price { get; set; }
+        }
+
+        [Test]
+        public void UpdateBatch( [DataContexts( ExcludeLinqService = true )] string context )
+        {
+            using ( var db = new TestDbManager( context ) )
+            {
+                var list = new[]
+				{
+					new TestProduct { ID = 1, Name = "Product 1", Price = 100m },
+					new TestProduct { ID = 2, Name = "Product 2", Price = null },
+				};
+
+                db.Update(5, list);
+            }
+        }
 	}
 }


### PR DESCRIPTION
Fixed error with the batch update when any nullable decimal member in the list was set to null. The BLToolkit was unable to determine the precision for the decimal type.