### PR TITLE
Implemented UseQueryText (as InlineParameters)

### DIFF
--- a/Source/Data/DbManager.Linq.cs
+++ b/Source/Data/DbManager.Linq.cs
@@ -80,6 +80,7 @@ namespace BLToolkit.Data
 			}
 
 			var sqlProvider = DataProvider.CreateSqlProvider();
+            sqlProvider.UseQueryText = this.UseQueryText;
 
 			var cc = sqlProvider.CommandCount(sql);
 			var sb = new StringBuilder();
@@ -112,7 +113,12 @@ namespace BLToolkit.Data
 		}
 
 		void GetParameters(IQueryContext query, PreparedQuery pq)
-		{
+        {
+            if (this.UseQueryText)
+            {
+                return;
+            }
+
 			var parameters = query.GetParameters();
 
 			if (parameters.Length == 0 && pq.SqlParameters.Count == 0)

--- a/Source/Data/Sql/SqlProvider/BasicSqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/BasicSqlProvider.cs
@@ -17,6 +17,12 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 	public abstract class BasicSqlProvider : ISqlProvider
 	{
+        public bool UseQueryText
+        {
+            get;
+            set;
+        }
+
 		#region Init
 
 		public SqlQuery SqlQuery { get; set; }
@@ -92,7 +98,9 @@ namespace BLToolkit.Data.Sql.SqlProvider
 						if (union.IsAll) sb.Append(" ALL");
 						sb.AppendLine();
 
-						CreateSqlProvider().BuildSql(commandNumber, union.SqlQuery, sb, indent, nesting, skipAlias);
+                        ISqlProvider sqlProvider = this.CreateSqlProvider();
+                        sqlProvider.UseQueryText = this.UseQueryText;
+                        sqlProvider.BuildSql(commandNumber, union.SqlQuery, sb, indent, nesting, skipAlias);
 					}
 				}
 			}
@@ -120,7 +128,9 @@ namespace BLToolkit.Data.Sql.SqlProvider
 			if (!IsTakeSupported && sqlQuery.Select.TakeValue != null)
 				throw new SqlException("Take for subqueries is not supported by the '{0}' provider.", Name);
 
-			return CreateSqlProvider().BuildSql(0, sqlQuery, sb, indent, nesting, skipAlias);
+            ISqlProvider sqlProvider = this.CreateSqlProvider();
+            sqlProvider.UseQueryText = this.UseQueryText;
+            return sqlProvider.BuildSql(0, sqlQuery, sb, indent, nesting, skipAlias);
 		}
 
 		protected abstract ISqlProvider CreateSqlProvider();
@@ -1519,7 +1529,7 @@ namespace BLToolkit.Data.Sql.SqlProvider
 					{
 						var parm = (SqlParameter)expr;
 
-						if (parm.IsQueryParameter)
+                        if (!this.UseQueryText && parm.IsQueryParameter)
 						{
 							var name = Convert(parm.Name, ConvertType.NameToQueryParameter);
 							sb.Append(name);

--- a/Source/Data/Sql/SqlProvider/ISqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/ISqlProvider.cs
@@ -22,6 +22,11 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 		string           Name                        { get; }
 		SqlQuery         SqlQuery                    { get; set; }
+        bool UseQueryText
+        {
+            get;
+            set;
+        }
 
 		bool             SkipAcceptsParameter        { get; }
 		bool             TakeAcceptsParameter        { get; }


### PR DESCRIPTION
Implemented UseQueryText (as InlineParameters) in order to generate a sql query instead of using command parameters. Useful for optimisations in select queries in oracle when having partitions over one column