### PR TITLE
InsertWithOutput implementation and cleanup

### DIFF
--- a/Source/Data/Sql/SqlProvider/BasicSqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/BasicSqlProvider.cs
@@ -178,9 +178,6 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 		protected virtual void BuildInsertQuery(StringBuilder sb)
 		{
-			if (SqlQuery.Insert.WithOutput)
-                		BuildSetOutput(sb);
-                
 			BuildStep = Step.InsertClause; BuildInsertClause(sb);
 
 			if (SqlQuery.QueryType == QueryType.Insert && SqlQuery.From.Tables.Count != 0)
@@ -196,9 +193,6 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 			if (SqlQuery.Insert.WithIdentity)
 				BuildGetIdentity(sb);
-				
-			if (SqlQuery.Insert.WithOutput)
-                		BuildGetOutput(sb);
 		}
 
 		protected virtual void BuildUnknownQuery(StringBuilder sb)
@@ -401,13 +395,6 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 				sb.AppendLine();
 				AppendIndent(sb).AppendLine(")");
-				
-				if ( SqlQuery.Insert.WithOutput )
-		                {
-		                    var pkField = SqlQuery.Insert.Into.Fields.FirstOrDefault(x=>x.Value.IsIdentity && x.Value.IsPrimaryKey);
-		
-		                    AppendIndent( sb ).Append( "output inserted.[" ).Append( pkField.Value.Name ).AppendLine( "] into @tabTempInsert" );
-		                }
 
 				if (SqlQuery.QueryType == QueryType.InsertOrUpdate || SqlQuery.From.Tables.Count == 0)
 				{
@@ -440,16 +427,6 @@ namespace BLToolkit.Data.Sql.SqlProvider
 		{
 			//throw new SqlException("Insert with identity is not supported by the '{0}' sql provider.", Name);
 		}
-		
-		protected virtual void BuildSetOutput(StringBuilder sb)
-	        {
-	            //throw new SqlException("Insert with identity is not supported by the '{0}' sql provider.", Name);
-	        }
-	
-	        protected virtual void BuildGetOutput(StringBuilder sb)
-	        {
-	            //throw new SqlException("Insert with identity is not supported by the '{0}' sql provider.", Name);
-	        }
 
 		#endregion
 

--- a/Source/Data/Sql/SqlProvider/PostgreSQLSqlProvider.cs
+++ b/Source/Data/Sql/SqlProvider/PostgreSQLSqlProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Text;
+using System.Linq;
 
 namespace BLToolkit.Data.Sql.SqlProvider
 {
@@ -157,6 +158,7 @@ namespace BLToolkit.Data.Sql.SqlProvider
 				case ConvertType.NameToQueryFieldAlias:
 				case ConvertType.NameToQueryTable:
 				case ConvertType.NameToQueryTableAlias:
+                case ConvertType.NameToOwner:
 					if (QuoteIdentifiers)
 					{
 						var name = value.ToString();
@@ -199,6 +201,93 @@ namespace BLToolkit.Data.Sql.SqlProvider
 
 			return base.GetIdentityExpression(table, identityField, forReturning);
 		}
+
+        protected override void BuildInsertClause( StringBuilder sb, string insertText, bool appendTableName )
+        {
+            AppendIndent(sb).Append(insertText);
+
+			if (appendTableName)
+				BuildPhysicalTable(sb, SqlQuery.Insert.Into, null);
+
+			if (SqlQuery.Insert.Items.Count == 0)
+			{
+				sb.Append(' ');
+				BuildEmptyInsert(sb);
+			}
+			else
+			{
+				sb.AppendLine();
+
+				AppendIndent(sb).AppendLine("(");
+
+				Indent++;
+
+				var first = true;
+
+				foreach (var expr in SqlQuery.Insert.Items)
+				{
+					if (!first)
+						sb.Append(',').AppendLine();
+					first = false;
+
+					AppendIndent(sb);
+					BuildExpression(sb, expr.Column, false, true);
+				}
+
+				Indent--;
+
+				sb.AppendLine();
+				AppendIndent(sb).AppendLine(")");
+
+				if (SqlQuery.QueryType == QueryType.InsertOrUpdate || SqlQuery.From.Tables.Count == 0)
+				{
+					AppendIndent(sb).AppendLine("VALUES");
+					AppendIndent(sb).AppendLine("(");
+
+					Indent++;
+
+					first = true;
+
+					foreach (var expr in SqlQuery.Insert.Items)
+					{
+						if (!first)
+							sb.Append(',').AppendLine();
+						first = false;
+
+						AppendIndent(sb);
+						BuildExpression(sb, expr.Expression);
+					}
+
+					Indent--;
+
+					sb.AppendLine();
+                    AppendIndent( sb ).AppendLine( ")" );
+
+                    if ( SqlQuery.Insert.WithOutput )
+                    {
+                        var pkField = SqlQuery.Insert.Into.Fields.FirstOrDefault( x => x.Value.IsIdentity && x.Value.IsPrimaryKey );
+
+                        var name = pkField.Value.Name;
+
+                        if ( QuoteIdentifiers && ( name.Length > 0 && name[0] != '"' ) )
+                            name = '"' + name + '"';
+
+                        sb.Append( string.Format( "RETURNING {0} as id", name ) );
+                    }
+				}
+			}
+        }
+
+        protected override void BuildInsertQuery( StringBuilder sb )
+        {
+            if (SqlQuery.Insert.WithOutput)
+                sb.Append( "WITH taboutput AS (" );
+
+            base.BuildInsertQuery( sb );
+
+            if (SqlQuery.Insert.WithOutput)
+                sb.AppendLine().Append( ")SELECT id FROM taboutput LIMIT 1" );
+        }
 
 		//protected override void BuildInsertOrUpdateQuery(StringBuilder sb)
 		//{


### PR DESCRIPTION
1. Implemented InsertWithOutput method for PostgreSql provider.
2. Cleaned code generation of InsertWithOutput for Sql Server provider.

Removed all unnecessary code from the BasicSqlProvider and moved it to the specified providers.

SqlServer generated sql:

    DECLARE @tabOutput TABLE(id UNIQUEIDENTIFIER)
    INSERT INTO [SchemaName].[TableName]
	(
		-- some fields
	)
	OUTPUT INSERTED.[TableNameID] INTO @tabOutput
	VALUES
	(
		-- some field values
	)
	SELECT TOP 1 id FROM @tabOutput

PostgreSql generated sql:

    WITH taboutput AS (INSERT INTO "SchemaName"."TableName"
	(
		-- some fields
	)
	VALUES
	(
		-- some field values
	)
	RETURNING "TableNameID" as id
	)SELECT id FROM taboutput LIMIT 1


