### PR TITLE
NullRefenceException at GetResultSets.

### DIFF
--- a/Source/Mapping/MappingSchema.cs
+++ b/Source/Mapping/MappingSchema.cs
@@ -3883,7 +3883,7 @@ namespace BLToolkit.Mapping
 
 				master.AddRelation(output[current], nr.SlaveIndex, nr.MasterIndex, nr.ContainerName);
 
-				current += GetResultSets(current + 1, output, output[current], nr.NextResults);
+				current = GetResultSets(current + 1, output, output[current], nr.NextResults);
 			}
 
 			return current;


### PR DESCRIPTION
NullRefenceException fixed at `ExecuteResultSet<T>` thowing in following example.

Object model:
```
public class Document
{
  [MapField("Id")]
  public long Id { get; set; }

  [MapField("DocumentType")]
  public string DocType { get; set; }

  [MapField("File")]
  public DocumentContent File { get; set; }

  [MapField("KeyValue")]
  public List<KeyValue> KeyValue { get; set; } = new List<KeyValue>();
}
public class DocumentContent
{
  public long DocumentId { get; set; }

  [MapField("Content")]
  public byte[] Content { get; set; }

  public SubContent Sub { get; set; }
}

public class SubContent
{
  public long ContentId { get; set; }
  public long Val { get; set; }
}
```
Using SQL procedure to return data.
```
CREATE procedure [dbo].[GetDocument]
@id bigint
as
begin
	set nocount on
	
	select * from Document where Id = @id
	select * from Content where DocumentId = @id
	(select @id as ContentId , @id as Val) -- sub content
	
	
	select * from KeyValue where DocumentId = @id
end
```

In accessor we have a method retutning `Document` object
```
var manager = GetDbManager();

var set = manager
  .SetSpCommand("GetDocument", manager.Parameter(ParameterDirection.Input, "@id", id))
  .ExecuteResultSet<Document>(
    new MapNextResult(typeof(DocumentContent), new MapIndex(new[] { "DocumentId" }), new MapIndex(new[] { "Id" }), "File",
    new MapNextResult(typeof(SubContent), new MapIndex(new[] { "ContentId" }), new MapIndex(new[] { "DocumentId" }), "Sub")),
    new MapNextResult(typeof(KeyValue), new MapIndex(new[] { "DocumentId" }), new MapIndex(new[] { "Id" }), "KeyValue"));

return (Document)set[0].List[0];
```